### PR TITLE
Removed unneeded synchronasation from reading dictionary files

### DIFF
--- a/src/main/java/de/danielnaber/jwordsplitter/tools/FastObjectSaver.java
+++ b/src/main/java/de/danielnaber/jwordsplitter/tools/FastObjectSaver.java
@@ -49,7 +49,7 @@ public class FastObjectSaver {
      * @param filenameInClassPath a plain text dictionary file in the classpath
      * @throws IOException
      */
-    public static synchronized Object load(String filenameInClassPath) throws IOException {
+    public static Object load(String filenameInClassPath) throws IOException {
         final InputStream is = FastObjectSaver.class.getResourceAsStream(filenameInClassPath);
         if (is == null) {
             throw new IOException("Cannot find dictionary in class path: " + filenameInClassPath);


### PR DESCRIPTION
Synchronized not needed here? As the dictionary files are passed durieng construction time, the file should be fixed. Or I am wrong? Synchronized writing maybe a solution for data integrity.
