### PR TITLE
Adds support to collect all subwords of a given word

### DIFF
--- a/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
+++ b/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
@@ -1,7 +1,7 @@
 /**
  * Copyright 2004-2007 Sven Abels
  * Copyright 2012 Daniel Naber (www.danielnaber.de)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -43,7 +43,6 @@ public abstract class AbstractWordSplitter {
     protected abstract Set<String> getWordList() throws IOException;
     protected abstract GermanInterfixDisambiguator getDisambiguator();
     protected abstract int getDefaultMinimumWordLength();
-
     /** Interfix elements in lowercase, e.g. at least "s" for German. */
     protected abstract Collection<String> getInterfixCharacters();
 

--- a/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
+++ b/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
@@ -4,7 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,9 +26,11 @@ import java.util.*;
  * will be split into "erhebung" and "fehler", if "erhebung" and "fehler" are in the dictionary
  * and "erhebungsfehler" is not. Thus how words are split only depends on the contents of
  * the dictionary. A dictionary for German is included.
+ *
  * <p>This is especially useful for German words but it will work with all languages.
  * The order of the words in the collection will be identical to their appearance in the
  * connected word. It's good to provide a large dictionary.
+ *
  * <p>Please note: We don't expect to have any special chars here (!":;,.-_, etc.). Only a set of
  * characters and only one word.
  *

--- a/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
+++ b/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
@@ -1,13 +1,10 @@
 /**
  * Copyright 2004-2007 Sven Abels
  * Copyright 2012 Daniel Naber (www.danielnaber.de)
- * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,11 +24,9 @@ import java.util.*;
  * will be split into "erhebung" and "fehler", if "erhebung" and "fehler" are in the dictionary
  * and "erhebungsfehler" is not. Thus how words are split only depends on the contents of
  * the dictionary. A dictionary for German is included.
- * <p>
  * <p>This is especially useful for German words but it will work with all languages.
  * The order of the words in the collection will be identical to their appearance in the
  * connected word. It's good to provide a large dictionary.
- * <p>
  * <p>Please note: We don't expect to have any special chars here (!":;,.-_, etc.). Only a set of
  * characters and only one word.
  *
@@ -40,11 +35,8 @@ import java.util.*;
 public abstract class AbstractWordSplitter {
 
     protected abstract Set<String> getWordList(InputStream stream) throws IOException;
-
     protected abstract Set<String> getWordList() throws IOException;
-
     protected abstract GermanInterfixDisambiguator getDisambiguator();
-
     protected abstract int getDefaultMinimumWordLength();
 
     /**
@@ -64,7 +56,7 @@ public abstract class AbstractWordSplitter {
      * Create a word splitter that uses the embedded dictionary.
      *
      * @param hideInterfixCharacters whether the word parts returned by {@link #splitWord(String)} still contain
-     *                               the connecting character (a.k.a. interfix)
+     *  the connecting character (a.k.a. interfix)
      */
     public AbstractWordSplitter(boolean hideInterfixCharacters) throws IOException {
         this.hideInterfixCharacters = hideInterfixCharacters;
@@ -73,9 +65,9 @@ public abstract class AbstractWordSplitter {
 
     /**
      * @param hideInterfixCharacters whether the word parts returned by {@link #splitWord(String)} still contain
-     *                               the connecting character (a.k.a. interfix)
-     * @param plainTextDict          a stream of a text file with one word per line, to be used instead of the embedded dictionary,
-     *                               must be in UTF-8 format
+     *  the connecting character (a.k.a. interfix)
+     * @param plainTextDict a stream of a text file with one word per line, to be used instead of the embedded dictionary,
+     *                       must be in UTF-8 format
      */
     public AbstractWordSplitter(boolean hideInterfixCharacters, InputStream plainTextDict) throws IOException {
         this.hideInterfixCharacters = hideInterfixCharacters;
@@ -84,9 +76,9 @@ public abstract class AbstractWordSplitter {
 
     /**
      * @param hideInterfixCharacters whether the word parts returned by {@link #splitWord(String)} still contain
-     *                               the connecting character (a.k.a. interfix)
-     * @param plainTextDict          a stream of a text file with one word per line, to be used instead of the embedded dictionary,
-     *                               must be in UTF-8 format
+     *  the connecting character (a.k.a. interfix)
+     * @param plainTextDict a stream of a text file with one word per line, to be used instead of the embedded dictionary,
+     *                       must be in UTF-8 format
      */
     public AbstractWordSplitter(boolean hideInterfixCharacters, File plainTextDict) throws IOException {
         this.hideInterfixCharacters = hideInterfixCharacters;
@@ -95,8 +87,8 @@ public abstract class AbstractWordSplitter {
 
     /**
      * @param hideInterfixCharacters whether the word parts returned by {@link #splitWord(String)} still contain
-     *                               the connecting character (a.k.a. interfix)
-     * @param words                  the compound part words
+     *  the connecting character (a.k.a. interfix)
+     * @param words the compound part words
      * @since 4.1
      */
     public AbstractWordSplitter(boolean hideInterfixCharacters, Set<String> words) throws IOException {
@@ -116,7 +108,7 @@ public abstract class AbstractWordSplitter {
 
     /**
      * @param filename UTF-8 encoded file with exceptions in the classpath, one exception per line, using pipe as delimiter.
-     *                 Example: <tt>Pilot|sendung</tt>
+     *   Example: <tt>Pilot|sendung</tt>
      */
     public void setExceptionFile(String filename) throws IOException {
         exceptionSplits = new ExceptionSplits(filename);
@@ -124,7 +116,7 @@ public abstract class AbstractWordSplitter {
 
     /**
      * @param completeWord the word for which an exception is to be defined (will be considered case-insensitive)
-     * @param wordParts    the parts in which the word is to be split (use a list with a single element if the word should not be split)
+     * @param wordParts the parts in which the word is to be split (use a list with a single element if the word should not be split)
      */
     public void addException(String completeWord, List<String> wordParts) {
         exceptionSplits.addSplit(completeWord.toLowerCase(), wordParts);
@@ -143,7 +135,6 @@ public abstract class AbstractWordSplitter {
      * has a typo. This could be used to split three-part compounds where one
      * part has a typo (the caller is then responsible for making useful corrections
      * out of these parts). Results are returned in no specific order.
-     *
      * @since 4.0
      */
     public List<List<String>> getAllSplits(String word) {
@@ -161,7 +152,7 @@ public abstract class AbstractWordSplitter {
     List<List<String>> getAllSplits(String word, boolean fromLeft) {
         List<List<String>> result = new ArrayList<>();
         int start = fromLeft ? minimumWordLength : word.length() - minimumWordLength;
-        for (int i = start; isLoopEnd(fromLeft, i, word); ) {
+        for (int i = start; isLoopEnd(fromLeft, i, word);) {
             String left = word.substring(0, i);
             String right = word.substring(i, word.length());
             String relevantWord = fromLeft ? left : right;
@@ -207,7 +198,7 @@ public abstract class AbstractWordSplitter {
 
     /**
      * @return a list of compound parts, with one element (the input word itself) if the input
-     * could not be split; returns an empty list if the input is {@code null}
+     *   could not be split; returns an empty list if the input is {@code null}
      */
     public List<String> splitWord(String word, boolean collectSubwords) {
         if (word == null) {

--- a/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
+++ b/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
@@ -236,7 +236,8 @@ public abstract class AbstractWordSplitter {
         String removableInterfix = findInterfixOrNull(lcWord);
         String wordWithoutInterfix = removeInterfix(word, removableInterfix);
         boolean canInterfixBeRemoved = removableInterfix != null && allowInterfixRemoval;
-        if (isSimpleWord(word)) {
+
+        if (isSimpleWord(word) && !collectSubwords) {
             parts = Collections.singletonList(word);
         } else if (canInterfixBeRemoved && isSimpleWord(wordWithoutInterfix)) {
             if (hideInterfixCharacters) {
@@ -246,6 +247,14 @@ public abstract class AbstractWordSplitter {
             }
         } else {
             parts = splitFromRight(word, collectSubwords);
+
+            if (parts == null && isSimpleWord(word)) {
+                parts = new ArrayList<>();
+                parts.add(word);
+            } else if (parts != null && isSimpleWord(word) && !parts.contains(word)) {
+                parts.add(word);
+            }
+
             if (parts == null && endsWithInterfix(lcWord)) {
                 parts = splitFromRight(wordWithoutInterfix, collectSubwords);
                 if (parts != null && !hideInterfixCharacters) {

--- a/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
+++ b/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
@@ -1,11 +1,12 @@
 /**
  * Copyright 2004-2007 Sven Abels
  * Copyright 2012 Daniel Naber (www.danielnaber.de)
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -43,9 +44,7 @@ public abstract class AbstractWordSplitter {
     protected abstract GermanInterfixDisambiguator getDisambiguator();
     protected abstract int getDefaultMinimumWordLength();
 
-    /**
-     * Interfix elements in lowercase, e.g. at least "s" for German.
-     */
+    /** Interfix elements in lowercase, e.g. at least "s" for German. */
     protected abstract Collection<String> getInterfixCharacters();
 
     protected Set<String> words = null;

--- a/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
+++ b/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
@@ -1,13 +1,13 @@
 /**
  * Copyright 2004-2007 Sven Abels
  * Copyright 2012 Daniel Naber (www.danielnaber.de)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,11 +27,11 @@ import java.util.*;
  * will be split into "erhebung" and "fehler", if "erhebung" and "fehler" are in the dictionary
  * and "erhebungsfehler" is not. Thus how words are split only depends on the contents of
  * the dictionary. A dictionary for German is included.
- *
+ * <p>
  * <p>This is especially useful for German words but it will work with all languages.
  * The order of the words in the collection will be identical to their appearance in the
  * connected word. It's good to provide a large dictionary.
- *
+ * <p>
  * <p>Please note: We don't expect to have any special chars here (!":;,.-_, etc.). Only a set of
  * characters and only one word.
  *
@@ -40,10 +40,16 @@ import java.util.*;
 public abstract class AbstractWordSplitter {
 
     protected abstract Set<String> getWordList(InputStream stream) throws IOException;
+
     protected abstract Set<String> getWordList() throws IOException;
+
     protected abstract GermanInterfixDisambiguator getDisambiguator();
+
     protected abstract int getDefaultMinimumWordLength();
-    /** Interfix elements in lowercase, e.g. at least "s" for German. */
+
+    /**
+     * Interfix elements in lowercase, e.g. at least "s" for German.
+     */
     protected abstract Collection<String> getInterfixCharacters();
 
     protected Set<String> words = null;
@@ -58,7 +64,7 @@ public abstract class AbstractWordSplitter {
      * Create a word splitter that uses the embedded dictionary.
      *
      * @param hideInterfixCharacters whether the word parts returned by {@link #splitWord(String)} still contain
-     *  the connecting character (a.k.a. interfix)
+     *                               the connecting character (a.k.a. interfix)
      */
     public AbstractWordSplitter(boolean hideInterfixCharacters) throws IOException {
         this.hideInterfixCharacters = hideInterfixCharacters;
@@ -67,9 +73,9 @@ public abstract class AbstractWordSplitter {
 
     /**
      * @param hideInterfixCharacters whether the word parts returned by {@link #splitWord(String)} still contain
-     *  the connecting character (a.k.a. interfix)
-     * @param plainTextDict a stream of a text file with one word per line, to be used instead of the embedded dictionary,
-     *                       must be in UTF-8 format
+     *                               the connecting character (a.k.a. interfix)
+     * @param plainTextDict          a stream of a text file with one word per line, to be used instead of the embedded dictionary,
+     *                               must be in UTF-8 format
      */
     public AbstractWordSplitter(boolean hideInterfixCharacters, InputStream plainTextDict) throws IOException {
         this.hideInterfixCharacters = hideInterfixCharacters;
@@ -78,9 +84,9 @@ public abstract class AbstractWordSplitter {
 
     /**
      * @param hideInterfixCharacters whether the word parts returned by {@link #splitWord(String)} still contain
-     *  the connecting character (a.k.a. interfix)
-     * @param plainTextDict a stream of a text file with one word per line, to be used instead of the embedded dictionary,
-     *                       must be in UTF-8 format
+     *                               the connecting character (a.k.a. interfix)
+     * @param plainTextDict          a stream of a text file with one word per line, to be used instead of the embedded dictionary,
+     *                               must be in UTF-8 format
      */
     public AbstractWordSplitter(boolean hideInterfixCharacters, File plainTextDict) throws IOException {
         this.hideInterfixCharacters = hideInterfixCharacters;
@@ -89,8 +95,8 @@ public abstract class AbstractWordSplitter {
 
     /**
      * @param hideInterfixCharacters whether the word parts returned by {@link #splitWord(String)} still contain
-     *  the connecting character (a.k.a. interfix)
-     * @param words the compound part words
+     *                               the connecting character (a.k.a. interfix)
+     * @param words                  the compound part words
      * @since 4.1
      */
     public AbstractWordSplitter(boolean hideInterfixCharacters, Set<String> words) throws IOException {
@@ -110,7 +116,7 @@ public abstract class AbstractWordSplitter {
 
     /**
      * @param filename UTF-8 encoded file with exceptions in the classpath, one exception per line, using pipe as delimiter.
-     *   Example: <tt>Pilot|sendung</tt>
+     *                 Example: <tt>Pilot|sendung</tt>
      */
     public void setExceptionFile(String filename) throws IOException {
         exceptionSplits = new ExceptionSplits(filename);
@@ -118,7 +124,7 @@ public abstract class AbstractWordSplitter {
 
     /**
      * @param completeWord the word for which an exception is to be defined (will be considered case-insensitive)
-     * @param wordParts the parts in which the word is to be split (use a list with a single element if the word should not be split)
+     * @param wordParts    the parts in which the word is to be split (use a list with a single element if the word should not be split)
      */
     public void addException(String completeWord, List<String> wordParts) {
         exceptionSplits.addSplit(completeWord.toLowerCase(), wordParts);
@@ -137,6 +143,7 @@ public abstract class AbstractWordSplitter {
      * has a typo. This could be used to split three-part compounds where one
      * part has a typo (the caller is then responsible for making useful corrections
      * out of these parts). Results are returned in no specific order.
+     *
      * @since 4.0
      */
     public List<List<String>> getAllSplits(String word) {
@@ -154,7 +161,7 @@ public abstract class AbstractWordSplitter {
     List<List<String>> getAllSplits(String word, boolean fromLeft) {
         List<List<String>> result = new ArrayList<>();
         int start = fromLeft ? minimumWordLength : word.length() - minimumWordLength;
-        for (int i = start; isLoopEnd(fromLeft, i, word);) {
+        for (int i = start; isLoopEnd(fromLeft, i, word); ) {
             String left = word.substring(0, i);
             String right = word.substring(i, word.length());
             String relevantWord = fromLeft ? left : right;
@@ -190,11 +197,19 @@ public abstract class AbstractWordSplitter {
         }
     }
 
+    public List<String> getSubWords(String word) {
+        return splitWord(word, true);
+    }
+
+    public List<String> splitWord(String word) {
+        return splitWord(word, false);
+    }
+
     /**
      * @return a list of compound parts, with one element (the input word itself) if the input
-     *   could not be split; returns an empty list if the input is {@code null}
+     * could not be split; returns an empty list if the input is {@code null}
      */
-    public List<String> splitWord(String word) {
+    public List<String> splitWord(String word, boolean collectSubwords) {
         if (word == null) {
             return Collections.emptyList();
         }
@@ -203,7 +218,7 @@ public abstract class AbstractWordSplitter {
         if (exceptionSplit != null) {
             return exceptionSplit;
         }
-        List<String> parts = split(trimmedWord, false);
+        List<String> parts = split(trimmedWord, false, collectSubwords);
         if (parts == null) {
             return Collections.singletonList(trimmedWord);
         }
@@ -224,7 +239,7 @@ public abstract class AbstractWordSplitter {
         }
     }
 
-    private List<String> split(String word, boolean allowInterfixRemoval) {
+    private List<String> split(String word, boolean allowInterfixRemoval, boolean collectSubwords) {
         List<String> parts;
         String lcWord = word.toLowerCase();
         String removableInterfix = findInterfixOrNull(lcWord);
@@ -239,9 +254,9 @@ public abstract class AbstractWordSplitter {
                 parts = Arrays.asList(wordWithoutInterfix, removableInterfix);
             }
         } else {
-            parts = splitFromRight(word);
+            parts = splitFromRight(word, collectSubwords);
             if (parts == null && endsWithInterfix(lcWord)) {
-                parts = splitFromRight(wordWithoutInterfix);
+                parts = splitFromRight(wordWithoutInterfix, collectSubwords);
                 if (parts != null && !hideInterfixCharacters) {
                     parts.add(removableInterfix);
                 }
@@ -250,7 +265,7 @@ public abstract class AbstractWordSplitter {
         return parts;
     }
 
-    private List<String> splitFromRight(String word) {
+    private List<String> splitFromRight(String word, boolean collectSubwords) {
         List<String> parts = null;
         for (int i = word.length() - minimumWordLength; i >= minimumWordLength; i--) {
             String leftPart = word.substring(0, i);
@@ -263,11 +278,27 @@ public abstract class AbstractWordSplitter {
                 }
             }
             if (isSimpleWord(rightPart)) {
-                List<String> leftPartParts = split(leftPart, true);
+                List<String> leftPartParts = split(leftPart, true, collectSubwords);
                 boolean isLeftPartAWord = leftPartParts != null;
                 if (isLeftPartAWord) {
-                    parts = new ArrayList<>(leftPartParts);
-                    parts.add(rightPart);
+                    if (collectSubwords) {
+                        if (parts == null) {
+                            parts = new ArrayList<>();
+                        }
+
+                        for (String leftPartPart : leftPartParts) {
+                            if (!parts.contains(leftPartPart)) {
+                                parts.add(leftPartPart);
+                            }
+                        }
+
+                        if (!parts.contains(rightPart)) {
+                            parts.add(rightPart);
+                        }
+                    } else {
+                        parts = new ArrayList<>(leftPartParts);
+                        parts.add(rightPart);
+                    }
                 } else if (!strictMode) {
                     parts = Arrays.asList(leftPart, rightPart);
                 }

--- a/src/test/java/de/danielnaber/jwordsplitter/BaseTest.java
+++ b/src/test/java/de/danielnaber/jwordsplitter/BaseTest.java
@@ -56,4 +56,9 @@ public abstract class BaseTest extends TestCase {
         assertEquals(expected, result.toString());
     }
 
+    protected void expectSubwords(String expected, String input) {
+        final List<String> result = splitter.getSubWords(input);
+        assertEquals(expected, result.toString());
+    }
+
 }

--- a/src/test/java/de/danielnaber/jwordsplitter/GermanWordSplitterTest.java
+++ b/src/test/java/de/danielnaber/jwordsplitter/GermanWordSplitterTest.java
@@ -260,11 +260,19 @@ public class GermanWordSplitterTest extends BaseTest {
     }
 
     public void testGetSubWords() throws IOException {
-        splitter = new GermanWordSplitter(false);
+        splitter = new GermanWordSplitter(true);
         expectSubwords("[Hammer, schlag, bohrer, schlagbohrer]", "Hammerschlagbohrer");
-        expectSubwords("[Sauerstoff, flasche]", "Sauerstoffflasche");
+        expectSubwords("[Sauer, stoff, Sauerstoff, flasche]", "Sauerstoffflasche");
+        expectSubwords("[Fahrzeug, taus, Fahr, zeug, staus]", "Fahrzeugstaus");
         splitter.addException("Hammerschlagbohrer", Arrays.asList("Hammer", "schlag", "bohrer"));
         expectSubwords("[Hammer, schlag, bohrer]", "Hammerschlagbohrer");
+
+        splitter = new GermanWordSplitter(true, tmpLexiconFile);
+        expectSubwords("[Kot, flügel, Kotflügel]", "Kotflügel");
+        splitter.addException("Kotflügel", Arrays.asList("Kot", "flügel"));
+        expectSubwords("[Kot, flügel]", "Kotflügel");
+        expectSubwords("[Verhalten, störung]", "Verhaltensstörung");
+        expectSubwords("[Bohrkopf]", "Bohrkopf");
     }
 
 }

--- a/src/test/java/de/danielnaber/jwordsplitter/GermanWordSplitterTest.java
+++ b/src/test/java/de/danielnaber/jwordsplitter/GermanWordSplitterTest.java
@@ -259,4 +259,12 @@ public class GermanWordSplitterTest extends BaseTest {
         } catch (NullPointerException ignored) {}
     }
 
+    public void testGetSubWords() throws IOException {
+        splitter = new GermanWordSplitter(false);
+        expectSubwords("[Hammer, schlag, bohrer, schlagbohrer]", "Hammerschlagbohrer");
+        expectSubwords("[Sauerstoff, flasche]", "Sauerstoffflasche");
+        splitter.addException("Hammerschlagbohrer", Arrays.asList("Hammer", "schlag", "bohrer"));
+        expectSubwords("[Hammer, schlag, bohrer]", "Hammerschlagbohrer");
+    }
+
 }


### PR DESCRIPTION
Motivation:

In some cases it whould be nice to collect all subwords that exist in the dictionary and not just one valid split (the longest). One example whould be if jwordsplitter is used to index data, e.g. in elasticsearch/lucene/solr and you want to use fuzzy queries. 
E.g. I want to index a document with the word "hammerschlagbohrer". Currently I whould index "hammer", "schlag" and "bohrer". That works fine in combination with a search interface and a user that will not input misspelled words. But if a user searches for "Schlagborer" (missing a "h"), we cannot easly split the input word. To bypass this problem easily, we could index "schlagbohrer" and use the fuzzy-constraint provided by lucene.

If you agree with the idea/implementation, I could add more regression tests for the new component. :)