### PR TITLE
Add surefire plugin for test-debugging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,16 @@
         </configuration>
       </plugin>
 
-      <plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.14</version>
+            <configuration>
+                <forkCount>0</forkCount>
+            </configuration>
+        </plugin>
+
+        <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.4</version>


### PR DESCRIPTION
Motivation:

Currently you cannot use break points in tests (IntelliJ 2017), same problem as mentioned in this thread: https://stackoverflow.com/questions/6573289/intellij-idea-debugger-skips-breakpoints-when-debugging-maven-tests

Adding surefire solves this problem.