### PR TITLE
Always check whether the word to split is an exception

### DIFF
--- a/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
+++ b/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
@@ -237,7 +237,10 @@ public abstract class AbstractWordSplitter {
     }
 
     private List<String> split(String word, boolean allowInterfixRemoval, boolean collectSubwords) {
-        List<String> parts;
+        List<String> parts = exceptionSplits.getExceptionSplitOrNull(word);
+        if (parts != null) {
+            return parts;
+        }
         String lcWord = word.toLowerCase();
         String removableInterfix = findInterfixOrNull(lcWord);
         String wordWithoutInterfix = removeInterfix(word, removableInterfix);
@@ -272,7 +275,11 @@ public abstract class AbstractWordSplitter {
     }
 
     private List<String> splitFromRight(String word, boolean collectSubwords) {
-        List<String> parts = null;
+        List<String> parts = exceptionSplits.getExceptionSplitOrNull(word);
+        if (parts != null) {
+            return parts;
+        }
+
         for (int i = word.length() - minimumWordLength; i >= minimumWordLength; i--) {
             String leftPart = word.substring(0, i);
             String rightPart = word.substring(i);

--- a/src/test/resources/de/danielnaber/jwordsplitter/test-de-large.txt
+++ b/src/test/resources/de/danielnaber/jwordsplitter/test-de-large.txt
@@ -148,7 +148,7 @@ Landschaft, wasser, haushalt
 Bomhardt
 Ost, bergs
 Zukunft, geschichte
-Bundestag, abgeordnete
+Bundes, tag, abgeordnete
 TV-Dauerbrenners
 Abfindung, vertrag
 Huberschen
@@ -1931,7 +1931,7 @@ Lehrstellen, statistik
 Fachwerk, häuschen
 Südchinesischen
 Kreidekliffs
-Bundesliga, Job
+Bundes, liga, Job
 Dax-Rallye
 Kometen, beobachter
 West, Journalisten


### PR DESCRIPTION
Whenever we split a word, we should first check whether it is a defined split exception.
I've corrected two test for which exceptions existed in exceptionsGerman.txt.