### PR TITLE
Check right part for an exception split

### DIFF
--- a/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
+++ b/src/main/java/de/danielnaber/jwordsplitter/AbstractWordSplitter.java
@@ -306,6 +306,14 @@ public abstract class AbstractWordSplitter {
                         if (!parts.contains(rightPart)) {
                             parts.add(rightPart);
                         }
+                        List<String> rightPartExceptions = exceptionSplits.getExceptionSplitOrNull(rightPart);
+                        if (rightPartExceptions != null) {
+                            for (String exception : rightPartExceptions) {
+                                if (!parts.contains(exception)) {
+                                    parts.add(exception);
+                                }
+                            }
+                        }
                     } else {
                         parts = new ArrayList<>(leftPartParts);
                         parts.add(rightPart);

--- a/src/test/java/de/danielnaber/jwordsplitter/GermanWordSplitterTest.java
+++ b/src/test/java/de/danielnaber/jwordsplitter/GermanWordSplitterTest.java
@@ -273,6 +273,9 @@ public class GermanWordSplitterTest extends BaseTest {
         expectSubwords("[Kot, flügel]", "Kotflügel");
         expectSubwords("[Verhalten, störung]", "Verhaltensstörung");
         expectSubwords("[Bohrkopf]", "Bohrkopf");
+        expectSubwords("[Hand, waschbecken]","Handwaschbecken");
+        splitter.addException("Waschbecken", Arrays.asList("Wasch", "becken"));
+        expectSubwords("[Hand, waschbecken, wasch, becken]","Handwaschbecken");
     }
 
 }

--- a/src/test/resources/de/danielnaber/jwordsplitter/test-de.txt
+++ b/src/test/resources/de/danielnaber/jwordsplitter/test-de.txt
@@ -17,3 +17,5 @@ Ei
 Haus
 Krawehl
 Pusselsumm
+Hand
+Waschbecken


### PR DESCRIPTION
This is done via split() for the left part above, but not for the right part. 
https://github.com/danielnaber/jwordsplitter/issues/19